### PR TITLE
Add scripts to genrate rc bug regression

### DIFF
--- a/bug_regression_CI/create_confluence_page_for_rc_bugs.sh
+++ b/bug_regression_CI/create_confluence_page_for_rc_bugs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# The script can be used locally to generate rc bug regression
+sudo pip install confluence-py
+sudo pip install bugzilla
+user==$2
+password=$3
+name=$4
+space=%5
+bug=$1
+echo 
+if [[ -e RC_CI ]]; then
+	echo "====Removing the useless dir============"
+	rm -rf RC_CI
+	echo "=============DONE======================="
+fi
+echo "======Git clone the scripts=============== "
+git clone https://github.com/testcara/RC_CI.git
+if [[ -e RC_CI ]];then
+	echo "======================DONE=================="
+else
+	echo "=============FAILED to get the file. Exit With error=========="
+	exit 1
+fi
+dir=$(pwd)
+cd ${dir}/RC_CI
+if [[  -e "${dir}/RC_CI/bug_regression_CI" ]]; then
+	echo "=======The target file has been found==============="
+	cd ${dir}/RC_CI/bug_regression_CI
+	echo "=======Generating the confluence page content for bugs============"
+	sudo python generate_confluence_page_for_bugs.py "${bug}"
+	if [[ -e 'content.txt' ]]; then
+		echo "==============Done========================="
+	else
+		echo "==========FAILED to generate the content. Exit with error"
+		exit 1
+	fi
+fi
+echo "==========Adding page to confluence==========="
+result=$(sudo confluence-cli --wikiurl="https://docs.engineering.redhat.com" -u ${user} -p ${password}  addpage -n "Bugs Regression Testing - ${name}" -s ${space}-f 'content.txt')
+if [[ ${result} =~ "https" ]]; then
+	echo "=========================Done: confluence page generated===================="
+	echo "====URL:https://docs.engineering.redhat.com/display/$5/Bugs Regression Testing - $4"
+else
+	echo "========FAILED: Creating page. Exit with error.===================="
+	echo "=========Error info:============"
+	echo ${result}
+	exit 1
+fi

--- a/bug_regression_CI/generate_confluence_page_for_bugs.py
+++ b/bug_regression_CI/generate_confluence_page_for_bugs.py
@@ -1,0 +1,99 @@
+#/bin/python2
+import pprint
+import bugzilla
+import sys
+
+'''
+    The scripts are used to generate the confluence content for bugs searched from bugzilla.
+    The top funcion is 'generate_confluence_page_for_bugs'.
+    And it would do the followging steps:
+    1. call function to generate the bz account config file.
+    2. call function to get bugs and format bugs
+    3. call function to generate the confluence content page for the bugs
+    4. remove the bz account config file. :)
+    The script can be used as 'sudo python generate_confluence_page_for_bugs.py username password '8380529, 123456'
+'''
+
+
+def generate_bugzilla_conf_file(user, password):
+	user_account = "[bugzilla.redhat.com]\n" + "user=" + user + "\n" + "password=" + password
+	f = open('/etc/bugzillarc', 'w')
+	f.write(user_account)
+	f.close
+
+def empty_bugzilla_conf_file():
+	content = " "
+	f = open('/etc/bugzillarc', 'w')
+	f.write(content)
+	f.close
+
+
+def get_bug_and_format_bug(bug_id):
+	bug_result = ""
+	bzapi = bugzilla.Bugzilla("bugzilla.redhat.com")
+	bug = bzapi.getbug(int(bug_id))
+	qe_flag = False
+	for flag in bug.flags:
+		if flag['name'] == "qe_auto_coverage":
+			qe_flag = True
+			qe_bug_flag = flag['status']
+		else:
+			next
+	bug_flag = qe_bug_flag if qe_flag else ""
+		
+
+	formatted_bug = [ bug.id, bug.summary, bug.component, bug.status, bug.severity, bug.priority, bug_flag, bug.qa_contact, bug_result ]
+	return formatted_bug
+
+def get_bugs_and_format_bugs(bugs_list):
+	formatted_bugs =[]
+	for bug in bugs_list:
+		formatted_bugs.append(get_bug_and_format_bug(bug))
+	return formatted_bugs
+
+def generate_page_content(formmatted_bugs_list):
+	table_column = ['ID', 'Summary', 'Component', 'Status', 'Severity', 'Priority', 'Flags', 'QAOwner', 'Result']
+	head_row = ""
+	for column_name in table_column:
+		head_row += "<th colspan='1'>" + column_name +"</th>"
+	headrow_html = "<tr>" + head_row + "</tr>"
+	bug_rows_html = ""
+	for formatted_bug in formmatted_bugs_list:
+		bug_rows_html += generate_bug_content(formatted_bug)
+	table_content = "<table><tbody>" + headrow_html + bug_rows_html + "</tbody></table>"
+	return table_content
+
+def write_page_file(table_content):
+	f = open('content.txt','w')
+	f.write(table_content)
+	f.close
+
+
+def generate_bug_content(formatted_bug):
+	bug_row = ""
+	bug_id = str(formatted_bug[0])
+	bug_details = formatted_bug[1:]
+	bug_id_td_html = '<td><a href=' + '"https://bugzilla.redhat.com/show_bug.cgi?id=' + bug_id + '">' + bug_id + "</a></td>"
+	for bug_item in bug_details:
+		bug_row += "<td>" + bug_item + "</td>"
+	bug_row_html = "<tr>" + bug_id_td_html + bug_row + "</tr>"
+	return bug_row_html
+
+
+def generate_confluence_page_for_bugs(user, password, bugs):
+	generate_bugzilla_conf_file(user, password)
+	formatted_bugs_list = get_bugs_and_format_bugs(bugs)
+	html = generate_page_content(formatted_bugs_list)
+	write_page_file(html)
+	empty_bugzilla_conf_file()
+
+
+if __name__== "__main__":
+	if len(sys.argv) < 4:
+		print len(sys.argv)
+		print "===Error===, username, password, bugs parameters are needed!"
+	else:
+		username = sys.argv[1]
+		password = sys.argv[2]
+        bugs_list = sys.argv[3:]
+        generate_confluence_page_for_bugs(username, password, bugs_list)

--- a/bug_regression_CI/jenkins_ci_rc_bug_regression_backup.sh
+++ b/bug_regression_CI/jenkins_ci_rc_bug_regression_backup.sh
@@ -1,0 +1,52 @@
+#/bin/bash
+# The script is one backup file which is copied from 'generating bug regression' CI.
+
+#1. get the bugs list
+bugs=$(echo ${bugs_link} | cut -d "=" -f 2 | sed  "s/&list_id//" | sed 's/%2C/ /g')
+echo "====Bugs: ${bugs}==================="
+#2. set the bugzilla username, confluence username
+bugzilla_username="${username}@redhat.com"
+confluence_username=${username}
+echo "The bugzilla account is ${bugzilla_username}, the confluence account is ${confluence_username}"
+#3. first install the confluence-py and bugzilla module, then get and run script to generate the conflunce content for the bug page, finally create the page on confluence
+sudo pip install confluence-py
+sudo pip install bugzilla
+sudo pip install requests
+if [[ -e "RC_CI" ]]; then
+	echo "====Removing the useless dir============"
+	rm -rf RC_CI
+	echo "=============DONE======================="
+fi
+echo "======Git clone the scripts=============== "
+git clone https://github.com/testcara/RC_CI.git
+if [[ -e "RC_CI" ]];then
+	echo "======================DONE=================="
+else
+	echo "=============FAILED to get the file. Exit With error=========="
+	exit 1
+fi
+dir=$(pwd)
+cd ${dir}/RC_CI
+if [[  -e "${dir}/RC_CI/bug_regression_CI" ]]; then
+	echo "=======The target file has been found==============="
+	cd ${dir}/RC_CI/bug_regression_CI
+	echo "=======Generating the confluence page content for bugs============"
+	sudo python generate_confluence_page_for_bugs.py ${bugzilla_username} ${password} ${bugs}
+	if [[ -e 'content.txt' ]]; then
+		echo "==============Done========================="
+	else
+		echo "==========FAILED to generate the content. Exit with error"
+		exit 1
+	fi
+fi
+echo "==========Adding page to confluence==========="
+result=$(sudo confluence-cli --wikiurl="https://docs.engineering.redhat.com" -u ${confluence_username} -p ${password}  addpage -n "Bugs Regression Testing - ${et_build_name}" -s ${space} -f 'content.txt')
+if [[ ${result} =~ "https" ]]; then
+	echo "=========================Done: confluence page generated===================="
+	echo "====URL:https://docs.engineering.redhat.com/display/$5/Bugs Regression Testing - $4"
+else
+	echo "========FAILED: Creating page. Exit with error.===================="
+	echo "=========Error info:============"
+	echo ${result}
+	exit 1
+fi


### PR DESCRIPTION
1. create_*.sh can be used locally to generate rc bug regression page
2. jenkins_*.sh can be copied to jenkins project directly to make
jenkins do the task
3. generate_*.py is one file to be called by the two scripts