### PR TITLE
Update the nightly_ci3.py for confluence user 'errata-qe'

### DIFF
--- a/auto_testing_CI/nightly_ci3.py
+++ b/auto_testing_CI/nightly_ci3.py
@@ -5,7 +5,7 @@ import time
 import talk_to_rc_jenkins as CI3_JENKINS
 
 class NightCI3Moniter():
-	def __init__(self, username, password, parent_page, build_rpm_ci_name, build_testing_ci_name, IS_COVERAGE_NEEDED):
+	def __init__(self, username, password, confluence_username, confluence_password, parent_page, build_rpm_ci_name, build_testing_ci_name, IS_COVERAGE_NEEDED):
 		self.username = username
 		self.password = password
 		self.confluence_username = confluence_username

--- a/auto_testing_CI/nightly_ci3.py
+++ b/auto_testing_CI/nightly_ci3.py
@@ -8,6 +8,8 @@ class NightCI3Moniter():
 	def __init__(self, username, password, parent_page, build_rpm_ci_name, build_testing_ci_name, IS_COVERAGE_NEEDED):
 		self.username = username
 		self.password = password
+		self.confluence_username = confluence_username
+		self.confluence_password = confluence_password
 		self.build_rpm_ci_name = build_rpm_ci_name
 		self.build_testing_ci_name = build_testing_ci_name
 		self.build_rpm_ci = CI3_JENKINS.TalkToRCCI(self.username, self.password, self.build_rpm_ci_name)
@@ -31,6 +33,8 @@ class NightCI3Moniter():
 		old_build_number = self.build_testing_ci_jenkins.get_job_info(self.build_testing_ci_name)['lastBuild']['number']
 		self.build_testing_parameter['username'] = self.username
 		self.build_testing_parameter['password'] = self.password
+		self.build_testing_parameter['confluence_username'] = self.confluence_username
+		self.build_testing_parameter['confluence_password'] = self.confluence_password
 		self.build_testing_parameter['et_build_name_or_id'] = self.build_id
 		self.build_testing_parameter['parent_page'] = self.parent_page
 		self.build_testing_parameter['IS_COVERAGE_NEEDED'] = self.IS_COVERAGE_NEEDED
@@ -46,11 +50,13 @@ class NightCI3Moniter():
 if __name__ == "__main__":
 	username = sys.argv[1]
 	password = sys.argv[2]
-	parent_page = sys.argv[3]
-	build_rpm_ci_name = sys.argv[4]
-	build_testing_ci_name = sys.argv[5]
-	IS_COVERAGE_NEEDED = sys.argv[6]
-	monitor = NightCI3Moniter(username, password, parent_page, build_rpm_ci_name, build_testing_ci_name, IS_COVERAGE_NEEDED)
+	confluence_username = sys.argv[3]
+	confluence_password = sys.argv[4]
+	parent_page = sys.argv[5]
+	build_rpm_ci_name = sys.argv[6]
+	build_testing_ci_name = sys.argv[7]
+	IS_COVERAGE_NEEDED = sys.argv[8]
+	monitor = NightCI3Moniter(username, password, confluence_username, confluence_password, parent_page, build_rpm_ci_name, build_testing_ci_name, IS_COVERAGE_NEEDED)
 	monitor.get_build_id()
 	monitor.run_ci3_build_testing()
 


### PR DESCRIPTION
This PR is to update nightly_ci3.py for confluence user 'errata-qe'.
In my last PR about user 'errata-qe', I forget to update the nightly_ci3.py, so later I update it in my project and use my repo in nightly CI jenkins job. We can see it works now.
So cara, please help to merge this PR. Thanks. 